### PR TITLE
dynamic laneless button 2/3

### DIFF
--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -82,7 +82,7 @@ const int CONTROLS_TIMEOUT = 5;
 const int bdr_s = 30;
 const int header_h = 420;
 const int footer_h = 280;
-const Rect laneless_btn = {1585, 905, 140, 140};
+const int laneless_btn_touch_pad = 80;
 
 const int UI_FREQ = 20;   // Hz
 
@@ -117,6 +117,7 @@ typedef struct UIScene {
   cereal::PandaState::PandaType pandaType;
 
   int laneless_mode;
+  Rect laneless_btn_touch_rect;
 
   cereal::CarState::Reader car_state;
   cereal::ControlsState::Reader controls_state;


### PR DESCRIPTION
three-part PR to reposition the laneless button and make it dynamic so it works on C3 with nav mode. 

The button press only works when you press the laneless button _in nave mode_, not otherwise, but that's because all screen presses in normal (sidebar hidden) mode are hijacked to switch to nav mode.

Looks pretty good.

I also blew it up a bit.

![IMG_0781](https://user-images.githubusercontent.com/7284371/134207816-a35adf70-3ba5-4d15-b192-3fc3357c4496.jpg)
![IMG_0778](https://user-images.githubusercontent.com/7284371/134207833-80409642-0eaa-41fa-8616-d29735908f84.jpg)
![IMG_0785](https://user-images.githubusercontent.com/7284371/134207839-296437a1-38c3-4efc-a257-aaa8f01dcdf6.jpg)

