### PR TITLE
Suppress C3 Nav toggle when DLP button is pressed

### DIFF
--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -72,7 +72,9 @@ void OnroadWindow::updateState(const UIState &s) {
 void OnroadWindow::mousePressEvent(QMouseEvent* e) {
   if (map != nullptr) {
     bool sidebarVisible = geometry().x() > 0;
-    map->setVisible(!sidebarVisible && !map->isVisible());
+    if (!QUIState::ui_state.scene.laneless_btn_touch_rect.ptInRect(e->x(), e->y())){
+      map->setVisible(!sidebarVisible && !map->isVisible());
+    }
   }
   // propagation event to parent(HomeWindow)
   QWidget::mousePressEvent(e);


### PR DESCRIPTION
On C3, any mouse press causes the onroad gui to 3-way toggle between map, sidebar, neither, and the laneless button only responds when pressed in nav mode.
Nav is now only toggled when the mouse press is not on the laneless button.

@twilsonco
  
Author
twilsonco commented now
Also with this the button button works when in nav or normal (no sidebar) mode.