### PR TITLE
Longitudinal Tune equal to stock

### DIFF
--- a/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
+++ b/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
@@ -34,7 +34,7 @@ X_EGO_COST = 0.
 V_EGO_COST = 0.
 A_EGO_COST = 0.
 J_EGO_COST = 5.0
-A_CHANGE_COST = .5
+A_CHANGE_COST = 0.
 DANGER_ZONE_COST = 100.
 CRASH_DISTANCE = .5
 LIMIT_COST = 1e6
@@ -49,9 +49,9 @@ T_IDXS_LST = [index_function(idx, max_val=MAX_T, max_idx=N+1) for idx in range(N
 T_IDXS = np.array(T_IDXS_LST)
 T_DIFFS = np.diff(T_IDXS, prepend=[0.])
 MIN_ACCEL = -3.5
-T_FOLLOW = 1.45
+T_FOLLOW = 1.25
 COMFORT_BRAKE = 2.5
-STOP_DISTANCE = 6.0
+STOP_DISTANCE = 5.0
 
 def get_stopped_equivalence_factor(v_lead):
   return (v_lead**2) / (2 * COMFORT_BRAKE)


### PR DESCRIPTION
I tested this adjustment and it was desirablely equal to the STOCK ACC, in heavy traffic the cars do not cut and nor honk complaining that it does not start to move as soon as the front car begins to move. When you're on the move following a car in front, you don't look "loose" and you don't get jerk acceleration. The distance when the car to the rear of the other is equal to the stock or it is possible to see the rear tires of the car in front. References of master: https://github.com/commaai/openpilot/pull/23441/commits/f1448ce015fc69176acce66505766fc1ee558995