### PR TITLE
Feature: `CameraOffset`

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -31,6 +31,7 @@ sunnypilot - Version 0.8.12-3
 
 sunnypilot - Version 0.8.12-2
 ========================
+* IMPROVED: Update Subaru car list in Force Car Recognition (#23) thanks to FrogAi!
 * NEW❗: Disable M.A.D.S. toggle to disable the beloved M.A.D.S. feature
   * Enable Stock openpilot engagement/disengagement
 * ADJUST: Initialize Driving Screen Off Brightness at 50%

--- a/selfdrive/common/params.cc
+++ b/selfdrive/common/params.cc
@@ -90,6 +90,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"BootedOnroad", CLEAR_ON_MANAGER_START | CLEAR_ON_IGNITION_OFF},
     {"BrightnessControl", PERSISTENT},
     {"CalibrationParams", PERSISTENT},
+    {"CameraOffset", PERSISTENT},
     {"CarBatteryCapacity", PERSISTENT},
     {"CarModel", PERSISTENT},
     {"CarParams", CLEAR_ON_MANAGER_START | CLEAR_ON_PANDA_DISCONNECT | CLEAR_ON_IGNITION_ON},

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -26,7 +26,6 @@ else:
   CAMERA_OFFSET = 0.0 + CameraOffset / 100
   PATH_OFFSET = 0.0 + CameraOffset / 100
 
-# print("New CAMERA_OFFSET value in M is:", CAMERA_OFFSET)
 
 class LanePlanner:
   def __init__(self, wide_camera=False):
@@ -50,18 +49,6 @@ class LanePlanner:
 
     self.camera_offset = -CAMERA_OFFSET if wide_camera else CAMERA_OFFSET
     self.path_offset = -PATH_OFFSET if wide_camera else PATH_OFFSET
-
-#    self.CameraOffset = None
-#    self.CameraOffset = None
-
-#  def update_sunny_set_offsets(self, camera_offset, path_offset):
-#    if self.CameraOffset != camera_offset:
-#      self.CameraOffset = camera_offset
-#      self.camera_offset = camera_offset / 100
-
-#    if self.CameraOffset != path_offset:
-#      self.CameraOffset = path_offset
-#      self.path_offset = path_offset / 100
 
   def parse_model(self, md):
     if len(md.laneLines) == 4 and len(md.laneLines[0].t) == TRAJECTORY_SIZE:

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -5,20 +5,28 @@ from common.numpy_fast import interp
 from common.realtime import DT_MDL
 from selfdrive.hardware import EON, TICI
 from selfdrive.swaglog import cloudlog
+from common.params import Params
 
 
 TRAJECTORY_SIZE = 33
 # camera offset is meters from center car to camera
-if EON:
-  CAMERA_OFFSET = 0.06
-  PATH_OFFSET = 0.0
-elif TICI:
-  CAMERA_OFFSET = -0.04
-  PATH_OFFSET = -0.04
-else:
-  CAMERA_OFFSET = 0.0
-  PATH_OFFSET = 0.0
 
+# Get offset from param file
+params = Params()
+CameraOffset = float(params.get("CameraOffset", encoding='utf8'))
+# print("User defined Camera Offset value in CM is:", CameraOffset)
+
+if EON:
+  CAMERA_OFFSET = 0.06 + CameraOffset / 100
+  PATH_OFFSET = 0.0 + CameraOffset / 100
+elif TICI:
+  CAMERA_OFFSET = -0.04 + CameraOffset / 100
+  PATH_OFFSET = -0.04 + CameraOffset / 100
+else:
+  CAMERA_OFFSET = 0.0 + CameraOffset / 100
+  PATH_OFFSET = 0.0 + CameraOffset / 100
+
+# print("New CAMERA_OFFSET value in M is:", CAMERA_OFFSET)
 
 class LanePlanner:
   def __init__(self, wide_camera=False):
@@ -42,6 +50,18 @@ class LanePlanner:
 
     self.camera_offset = -CAMERA_OFFSET if wide_camera else CAMERA_OFFSET
     self.path_offset = -PATH_OFFSET if wide_camera else PATH_OFFSET
+
+#    self.CameraOffset = None
+#    self.CameraOffset = None
+
+#  def update_sunny_set_offsets(self, camera_offset, path_offset):
+#    if self.CameraOffset != camera_offset:
+#      self.CameraOffset = camera_offset
+#      self.camera_offset = camera_offset / 100
+
+#    if self.CameraOffset != path_offset:
+#      self.CameraOffset = path_offset
+#      self.path_offset = path_offset / 100
 
   def parse_model(self, md):
     if len(md.laneLines) == 4 and len(md.laneLines[0].t) == TRAJECTORY_SIZE:

--- a/selfdrive/controls/lib/lateral_planner.py
+++ b/selfdrive/controls/lib/lateral_planner.py
@@ -87,7 +87,6 @@ class LateralPlanner:
     if self.second > 1.0:
       self.use_lanelines = not Params().get_bool("EndToEndToggle")
       self.dynamic_lane_profile = int(Params().get("DynamicLaneProfile", encoding="utf8"))
-    # self.LP.update_sunny_set_offsets = int(Params().get("CameraOffset", encoding="utf8"))
       self.second = 0.0
     self.stand_still = sm['carState'].standStill
 

--- a/selfdrive/controls/lib/lateral_planner.py
+++ b/selfdrive/controls/lib/lateral_planner.py
@@ -87,6 +87,7 @@ class LateralPlanner:
     if self.second > 1.0:
       self.use_lanelines = not Params().get_bool("EndToEndToggle")
       self.dynamic_lane_profile = int(Params().get("DynamicLaneProfile", encoding="utf8"))
+    # self.LP.update_sunny_set_offsets = int(Params().get("CameraOffset", encoding="utf8"))
       self.second = 0.0
     self.stand_still = sm['carState'].standStill
 

--- a/selfdrive/ui/qt/widgets/sunnypilot.cc
+++ b/selfdrive/ui/qt/widgets/sunnypilot.cc
@@ -97,7 +97,7 @@ AutoLaneChangeTimer::AutoLaneChangeTimer() : AbstractControl("Auto Lane Change T
   btnminus.setStyleSheet(R"(
     padding: 0;
     border-radius: 50px;
-    font-size: 55px;
+    font-size: 50px;
     font-weight: 500;
     color: #E4E4E4;
     background-color: #393939;
@@ -105,7 +105,7 @@ AutoLaneChangeTimer::AutoLaneChangeTimer() : AbstractControl("Auto Lane Change T
   btnplus.setStyleSheet(R"(
     padding: 0;
     border-radius: 50px;
-    font-size: 55px;
+    font-size: 50px;
     font-weight: 500;
     color: #E4E4E4;
     background-color: #393939;
@@ -172,7 +172,7 @@ BrightnessControl::BrightnessControl() : AbstractControl("Brightness Control (Gl
   btnminus.setStyleSheet(R"(
     padding: 0;
     border-radius: 50px;
-    font-size: 55px;
+    font-size: 35px;
     font-weight: 500;
     color: #E4E4E4;
     background-color: #393939;
@@ -180,7 +180,7 @@ BrightnessControl::BrightnessControl() : AbstractControl("Brightness Control (Gl
   btnplus.setStyleSheet(R"(
     padding: 0;
     border-radius: 50px;
-    font-size: 55px;
+    font-size: 35px;
     font-weight: 500;
     color: #E4E4E4;
     background-color: #393939;
@@ -241,7 +241,7 @@ OnroadScreenOff::OnroadScreenOff() : AbstractControl("Driving Screen Off Timer",
   btnminus.setStyleSheet(R"(
     padding: 0;
     border-radius: 50px;
-    font-size: 55px;
+    font-size: 35px;
     font-weight: 500;
     color: #E4E4E4;
     background-color: #393939;
@@ -249,7 +249,7 @@ OnroadScreenOff::OnroadScreenOff() : AbstractControl("Driving Screen Off Timer",
   btnplus.setStyleSheet(R"(
     padding: 0;
     border-radius: 50px;
-    font-size: 55px;
+    font-size: 35px;
     font-weight: 500;
     color: #E4E4E4;
     background-color: #393939;
@@ -315,7 +315,7 @@ OnroadScreenOffBrightness::OnroadScreenOffBrightness() : AbstractControl("Drivin
   btnminus.setStyleSheet(R"(
     padding: 0;
     border-radius: 50px;
-    font-size: 55px;
+    font-size: 35px;
     font-weight: 500;
     color: #E4E4E4;
     background-color: #393939;
@@ -323,7 +323,7 @@ OnroadScreenOffBrightness::OnroadScreenOffBrightness() : AbstractControl("Drivin
   btnplus.setStyleSheet(R"(
     padding: 0;
     border-radius: 50px;
-    font-size: 55px;
+    font-size: 35px;
     font-weight: 500;
     color: #E4E4E4;
     background-color: #393939;
@@ -384,7 +384,7 @@ CameraOffset::CameraOffset() : AbstractControl("Camera Offset Value (cm)",
   btnminus.setStyleSheet(R"(
     padding: 0;
     border-radius: 50px;
-    font-size: 55px;
+    font-size: 35px;
     font-weight: 500;
     color: #E4E4E4;
     background-color: #393939;
@@ -392,7 +392,7 @@ CameraOffset::CameraOffset() : AbstractControl("Camera Offset Value (cm)",
   btnplus.setStyleSheet(R"(
     padding: 0;
     border-radius: 50px;
-    font-size: 55px;
+    font-size: 35px;
     font-weight: 500;
     color: #E4E4E4;
     background-color: #393939;
@@ -457,7 +457,7 @@ MaxTimeOffroad::MaxTimeOffroad() : AbstractControl("Max Time Offroad",
   btnminus.setStyleSheet(R"(
     padding: 0;
     border-radius: 50px;
-    font-size: 45px;
+    font-size: 35px;
     font-weight: 500;
     color: #E4E4E4;
     background-color: #393939;
@@ -465,7 +465,7 @@ MaxTimeOffroad::MaxTimeOffroad() : AbstractControl("Max Time Offroad",
   btnplus.setStyleSheet(R"(
     padding: 0;
     border-radius: 50px;
-    font-size: 45px;
+    font-size: 35px;
     font-weight: 500;
     color: #E4E4E4;
     background-color: #393939;

--- a/selfdrive/ui/qt/widgets/sunnypilot.cc
+++ b/selfdrive/ui/qt/widgets/sunnypilot.cc
@@ -97,7 +97,7 @@ AutoLaneChangeTimer::AutoLaneChangeTimer() : AbstractControl("Auto Lane Change T
   btnminus.setStyleSheet(R"(
     padding: 0;
     border-radius: 50px;
-    font-size: 50px;
+    font-size: 55px;
     font-weight: 500;
     color: #E4E4E4;
     background-color: #393939;
@@ -105,7 +105,7 @@ AutoLaneChangeTimer::AutoLaneChangeTimer() : AbstractControl("Auto Lane Change T
   btnplus.setStyleSheet(R"(
     padding: 0;
     border-radius: 50px;
-    font-size: 50px;
+    font-size: 55px;
     font-weight: 500;
     color: #E4E4E4;
     background-color: #393939;
@@ -172,7 +172,7 @@ BrightnessControl::BrightnessControl() : AbstractControl("Brightness Control (Gl
   btnminus.setStyleSheet(R"(
     padding: 0;
     border-radius: 50px;
-    font-size: 35px;
+    font-size: 55px;
     font-weight: 500;
     color: #E4E4E4;
     background-color: #393939;
@@ -180,7 +180,7 @@ BrightnessControl::BrightnessControl() : AbstractControl("Brightness Control (Gl
   btnplus.setStyleSheet(R"(
     padding: 0;
     border-radius: 50px;
-    font-size: 35px;
+    font-size: 55px;
     font-weight: 500;
     color: #E4E4E4;
     background-color: #393939;
@@ -241,7 +241,7 @@ OnroadScreenOff::OnroadScreenOff() : AbstractControl("Driving Screen Off Timer",
   btnminus.setStyleSheet(R"(
     padding: 0;
     border-radius: 50px;
-    font-size: 35px;
+    font-size: 55px;
     font-weight: 500;
     color: #E4E4E4;
     background-color: #393939;
@@ -249,7 +249,7 @@ OnroadScreenOff::OnroadScreenOff() : AbstractControl("Driving Screen Off Timer",
   btnplus.setStyleSheet(R"(
     padding: 0;
     border-radius: 50px;
-    font-size: 35px;
+    font-size: 55px;
     font-weight: 500;
     color: #E4E4E4;
     background-color: #393939;
@@ -315,7 +315,7 @@ OnroadScreenOffBrightness::OnroadScreenOffBrightness() : AbstractControl("Drivin
   btnminus.setStyleSheet(R"(
     padding: 0;
     border-radius: 50px;
-    font-size: 35px;
+    font-size: 55px;
     font-weight: 500;
     color: #E4E4E4;
     background-color: #393939;
@@ -323,7 +323,7 @@ OnroadScreenOffBrightness::OnroadScreenOffBrightness() : AbstractControl("Drivin
   btnplus.setStyleSheet(R"(
     padding: 0;
     border-radius: 50px;
-    font-size: 35px;
+    font-size: 55px;
     font-weight: 500;
     color: #E4E4E4;
     background-color: #393939;
@@ -372,6 +372,79 @@ void OnroadScreenOffBrightness::refresh() {
   btnplus.setText("+");
 }
 
+// Camera Offset Value (Default offset value for C3 is 0.04 (4cm but in meters)).
+CameraOffset::CameraOffset() : AbstractControl("Camera Offset Value (cm)",
+                                               "Hack to trick vehicle to be left or right biased in its lane. Decreasing the value will make the car keep more right, increasing will make it keep more left. Must be set while offroad",
+                                               "../assets/offroad/icon_metric.png") {
+
+  label.setAlignment(Qt::AlignVCenter|Qt::AlignRight);
+  label.setStyleSheet("color: #e0e879");
+  hlayout->addWidget(&label);
+
+  btnminus.setStyleSheet(R"(
+    padding: 0;
+    border-radius: 50px;
+    font-size: 55px;
+    font-weight: 500;
+    color: #E4E4E4;
+    background-color: #393939;
+  )");
+  btnplus.setStyleSheet(R"(
+    padding: 0;
+    border-radius: 50px;
+    font-size: 55px;
+    font-weight: 500;
+    color: #E4E4E4;
+    background-color: #393939;
+  )");
+  btnminus.setFixedSize(150, 100);
+  btnplus.setFixedSize(150, 100);
+  hlayout->addWidget(&btnminus);
+  hlayout->addWidget(&btnplus);
+
+QObject::connect(&btnminus, &QPushButton::clicked, [=]() {
+    auto str = QString::fromStdString(params.get("CameraOffset"));
+    int value = str.toInt();
+    value = value - 1;
+//    int valueInM = str.toInt();
+//    valueInM = value / 100;
+    if (value <= -10 ) {
+      value = -10;
+    }
+
+    QString values = QString::number(value);
+    params.put("CameraOffset", values.toStdString());
+//    QString valuesinM = QString::number(valueInM);
+//    params.put("CameraOffsetinM", valuesinM.toStdString());
+    refresh();
+  });
+
+  QObject::connect(&btnplus, &QPushButton::clicked, [=]() {
+    auto str = QString::fromStdString(params.get("CameraOffset"));
+    int value = str.toInt();
+    value = value + 1;
+//    int valueInM = str.toInt();
+//    valueInM = value / 100;
+    if (value >= 10 ) {
+      value = 10;
+    }
+
+    QString values = QString::number(value);
+    params.put("CameraOffset", values.toStdString());
+//    QString valuesinM = QString::number(valueInM);
+//    params.put("CameraOffsetinM", valuesinM.toStdString());
+    refresh();
+  });
+  refresh();
+}
+
+void CameraOffset::refresh() {
+  QString option = QString::fromStdString(params.get("CameraOffset"));
+  label.setText(QString::fromStdString(params.get("CameraOffset")));
+  btnminus.setText("-");
+  btnplus.setText("+");
+}
+
 // Max Time Offroad (Shutdown timer)
 MaxTimeOffroad::MaxTimeOffroad() : AbstractControl("Max Time Offroad",
                                                    "Device is automatically turned off after a set time when the engine is turned off (off-road) after driving (on-road).",
@@ -384,7 +457,7 @@ MaxTimeOffroad::MaxTimeOffroad() : AbstractControl("Max Time Offroad",
   btnminus.setStyleSheet(R"(
     padding: 0;
     border-radius: 50px;
-    font-size: 35px;
+    font-size: 45px;
     font-weight: 500;
     color: #E4E4E4;
     background-color: #393939;
@@ -392,7 +465,7 @@ MaxTimeOffroad::MaxTimeOffroad() : AbstractControl("Max Time Offroad",
   btnplus.setStyleSheet(R"(
     padding: 0;
     border-radius: 50px;
-    font-size: 35px;
+    font-size: 45px;
     font-weight: 500;
     color: #E4E4E4;
     background-color: #393939;

--- a/selfdrive/ui/qt/widgets/sunnypilot.h
+++ b/selfdrive/ui/qt/widgets/sunnypilot.h
@@ -95,3 +95,18 @@ private:
 
   void refresh();
 };
+
+class CameraOffset : public AbstractControl {
+  Q_OBJECT
+
+public:
+  CameraOffset();
+
+private:
+  QPushButton btnplus;
+  QPushButton btnminus;
+  QLabel label;
+  Params params;
+
+  void refresh();
+};


### PR DESCRIPTION
Couple of  notes this with this PR: 

1) I set a few params to be [ON] by default in between installs, namely:
- Training is marked as completed so don't have redo between installs.
- Terms and Conditions have been accepted.
- Turn on:
   - Lane Departure Warning, 
   - Right hand drive 
   - Metric units.
- Enable `Quiet Drive` by default.
- Enable `SSH` by default.

2) This also implements PR: https://github.com/commaai/openpilot/commit/233a6e4a625a8ef145904522e4663177bcd3d65d

3) Visual change: Increased the font size of the +/- buttons slightly.

4) Line 55-64 in `selfdrive/controls/lib/lane_planner.py` is from DP's Camera Offset feature. I think this can be altered to update the variable without turning off and on the car (TODO) 

5) This is compatible with all hardware.