### PR TITLE
Fix crash on brake pressed on subaru forester

### DIFF
--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -75,9 +75,9 @@ class CarState(CarStateBase):
       ret.brakePressed = cp.vl["Brake_Status"]["Brake"] == 1
 
     if self.car_fingerprint in PREGLOBAL_CARS:
-      ret.brakeLights = cp_cam.vl["ES_Brake"]["Brake_Light"] == 1 or ret.brakePressed
+      ret.brakeLights = bool(cp_cam.vl["ES_Brake"]["Brake_Light"] or ret.brakePressed)
     else:
-      ret.brakeLights = cp_cam.vl["ES_DashStatus"]["Brake_Lights"] == 1 or ret.brakePressed
+      ret.brakeLights = bool(cp_cam.vl["ES_DashStatus"]["Brake_Lights"] or ret.brakePressed)
 
     if self.car_fingerprint == CAR.OUTBACK:
       ret.wheelSpeeds = self.get_wheel_speeds(

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -75,9 +75,9 @@ class CarState(CarStateBase):
       ret.brakePressed = cp.vl["Brake_Status"]["Brake"] == 1
 
     if self.car_fingerprint in PREGLOBAL_CARS:
-      ret.brakeLights = cp_cam.vl["ES_Brake"]["Brake_Light"] or ret.brakePressed
+      ret.brakeLights = cp_cam.vl["ES_Brake"]["Brake_Light"] == 1 or ret.brakePressed
     else:
-      ret.brakeLights = cp_cam.vl["ES_DashStatus"]["Brake_Lights"] or ret.brakePressed
+      ret.brakeLights = cp_cam.vl["ES_DashStatus"]["Brake_Lights"] == 1 or ret.brakePressed
 
     if self.car_fingerprint == CAR.OUTBACK:
       ret.wheelSpeeds = self.get_wheel_speeds(


### PR DESCRIPTION
The brake_light signal is not a boolean (it is an int, 1 for true and 0 for false), which caused a crash

short drive: https://connect.comma.ai/111b7e3a9ff2341a/1646862114749/1646862349196